### PR TITLE
fix a typo in the date of the webinar

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -680,7 +680,7 @@ If you are ready to make your resources available to trainees, just send an emai
 
 # Replay of past webinars
 
-A webinar tool place on 2015, December 10th to present the starting pack. If you missed it, you can have a look at the replay. 
+A webinar tool place on 2025, December 10th to present the starting pack. If you missed it, you can have a look at the replay. 
 
 {{< video https://minio.lab.sspcloud.fr/nicolastlm/diffusion/Webinaire_AIML4OS_WP6_2015_12_10.mp4 >}}
 


### PR DESCRIPTION
There's a typo in the date of the webinar (the year was 2025 not 2015).
This PR fixes that.